### PR TITLE
[feat] chat module 예외 처리, 기능 구현 #7

### DIFF
--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -117,10 +117,10 @@ export class ChatController {
 	@ApiOperation({ summary: '채팅방 참여자 목록 조회' })
 	@Get('/:roomId/members')
 	@UseGuards(RoomGuard)
-	getPariticipants(
+	getParticipants(
 		@Param('roomId', ParseIntPipe) roomId: number
 	): Promise<ChatParticipantDto[]> {
-		return this.chatService.getPariticipants(roomId);
+		return this.chatService.getParticipants(roomId);
 	}
 
 	@ApiOperation({ summary: '채팅방 역할 변경' })

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -56,7 +56,7 @@ export class ChatController {
 	@ApiOperation({ summary: '오픈 채팅방 목록 조회' })
 	@Get('/opened')
 	inquireOpenedChatRoom(): Promise<ChatRoomDto[]> {
-		return this.chatService.inquireOpenedChatRoom();
+		return this.chatService.inquireOpenedChatRoom(2); //temp
 	}
 
 	@ApiOperation({ summary: '채팅방 입장' })

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -20,6 +20,7 @@ import { ChatRoomDto } from 'src/chat/dto/chat-room.dto';
 import { ChatDto } from 'src/chat/dto/chat.dto';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
+import { DmDto } from 'src/chat/dto/dm.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
 import { GetDMDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
@@ -44,6 +45,13 @@ export class ChatController {
 		@Body() createChatRoomDto: CreateChatRoomDto
 	): Promise<ChatRoomDto> {
 		return this.chatService.createChatRoom(createChatRoomDto);
+	}
+
+	@ApiOperation({ summary: 'dm 채팅방 리스트 조회' })
+	@Get('/dm')
+	@UsePipes(ValidationPipe)
+	inquireDM(): Promise<DmDto[]> {
+		return this.chatService.inquireDM(1); //temp
 	}
 
 	@ApiOperation({ summary: 'dm 채팅방 입장' })

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -21,7 +21,7 @@ import { ChatDto } from 'src/chat/dto/chat.dto';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
-import { GetPrivateChatRoomDto } from 'src/chat/dto/get-private-chat-room.dto';
+import { GetDMDto } from 'src/chat/dto/get-DM.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
 import { SetParticipantStatusDto } from 'src/chat/dto/set-participant-status.dto';
 import { RoomGuard } from 'src/chat/guards/room.guard';
@@ -49,10 +49,8 @@ export class ChatController {
 	@ApiOperation({ summary: 'dm 채팅방 입장' })
 	@Post('/dm')
 	@UsePipes(ValidationPipe)
-	getPrivateChatRoom(
-		@Body() getPrivateChatRoomDto: GetPrivateChatRoomDto
-	): Promise<ChatRoomDto> {
-		return this.chatService.getPrivateChatRoom(getPrivateChatRoomDto);
+	getDM(@Body() getDMDto: GetDMDto): Promise<ChatRoomDto> {
+		return this.chatService.getDM(getDMDto);
 	}
 
 	@ApiOperation({ summary: '오픈 채팅방 목록 조회' })

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -21,7 +21,7 @@ import { ChatDto } from 'src/chat/dto/chat.dto';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
-import { GetDMDto } from 'src/chat/dto/get-DM.dto';
+import { GetDMDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
 import { SetParticipantStatusDto } from 'src/chat/dto/set-participant-status.dto';
 import { RoomGuard } from 'src/chat/guards/room.guard';

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -22,7 +22,7 @@ import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
 import { DmDto } from 'src/chat/dto/dm.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
-import { GetDMDto } from 'src/chat/dto/get-dm.dto';
+import { GetDmDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
 import { SetParticipantStatusDto } from 'src/chat/dto/set-participant-status.dto';
 import { RoomGuard } from 'src/chat/guards/room.guard';
@@ -50,15 +50,15 @@ export class ChatController {
 	@ApiOperation({ summary: 'dm 채팅방 리스트 조회' })
 	@Get('/dm')
 	@UsePipes(ValidationPipe)
-	inquireDM(): Promise<DmDto[]> {
-		return this.chatService.inquireDM(1); //temp
+	inquireDm(): Promise<DmDto[]> {
+		return this.chatService.inquireDm(1); //temp
 	}
 
 	@ApiOperation({ summary: 'dm 채팅방 입장' })
 	@Post('/dm')
 	@UsePipes(ValidationPipe)
-	getDM(@Body() getDMDto: GetDMDto): Promise<ChatRoomDto> {
-		return this.chatService.getDM(getDMDto);
+	getDm(@Body() getDmDto: GetDmDto): Promise<ChatRoomDto> {
+		return this.chatService.getDm(getDmDto);
 	}
 
 	@ApiOperation({ summary: '오픈 채팅방 목록 조회' })

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -100,7 +100,7 @@ export class ChatService {
 	 * 채팅방 참가자의 상태를 확인한다.
 	 * @param participants
 	 * @param user
-	 * @returns 참가자의 상태를 반환한다.
+	 * @returns 참가자의 상태를 반환한다. 참가하지 않은 유저면 null을 반환한다.
 	 */
 	getParticipantStatus(
 		participants: ChatParticipant[],
@@ -111,7 +111,9 @@ export class ChatService {
 				return participant;
 			}
 		});
-		//참여자 아닌 경우
+		if (participant === undefined) {
+			return null;
+		}
 		return participant.status;
 	}
 
@@ -230,15 +232,20 @@ export class ChatService {
 	}
 
 	/**
-	 * 존재하는 오픈 채팅방을 조회한다.
+	 * 존재하는 오픈 채팅방 중 사용자가 밴 당하지 않은 채팅방을 조회한다.
 	 * @returns 존재하는 오픈 채팅방 리스트를 반환한다.
 	 */
 	async inquireOpenedChatRoom(userId: number): Promise<ChatRoomDto[]> {
 		const user = await this.userRepository.findUserById(userId); //temp
 
-		return this.roomsEntityToDto(
-			await this.chatRoomRepository.inquireOpenedChatRoom(user)
+		const allRoom = await this.chatRoomRepository.inquireOpenedChatRoom(user);
+		const roomsWithoutBanned = allRoom.filter(
+			(room) =>
+				this.getParticipantStatus(room.participants, user) !==
+				PaticipantStatus.BANNED
 		);
+
+		return this.roomsEntityToDto(roomsWithoutBanned);
 	}
 
 	/**

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -263,7 +263,7 @@ export class ChatService {
 	}
 
 	/**
-	 * 유저가 참여하고있는 모든 chat-room을 조회한다.
+	 * 유저가 참여하고있는 모든 chat-room을 조회한다(DM제외).
 	 * @param userId
 	 * @returns 참여하고있는 chat-room 리스트를 반환한다.
 	 */

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -96,6 +96,25 @@ export class ChatService {
 	}
 
 	/**
+	 * 채팅방 참가자의 상태를 확인한다.
+	 * @param participants
+	 * @param user
+	 * @returns 참가자의 상태를 반환한다.
+	 */
+	getParticipantStatus(
+		participants: ChatParticipant[],
+		user: User
+	): PaticipantStatus {
+		const participant = participants.find((participant) => {
+			if (participant.user.id == user.id) {
+				return participant;
+			}
+		});
+		//참여자 아닌 경우
+		return participant.status;
+	}
+
+	/**
 	 * dm방을 반환한다.
 	 * @param getPrivateChatRoomDto 대화를 나눌 유저의 정보가 담긴 dto
 	 * @returns dm room을 반환한다.

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -260,6 +260,12 @@ export class ChatService {
 		}
 		const user = await this.userRepository.findUserById(1); //temp
 		if (this.checkUserInParticipant(room.participants, user)) {
+			if (
+				this.getParticipantStatus(room.participants, user) ==
+				PaticipantStatus.BANNED
+			) {
+				throw new UnauthorizedException();
+			}
 			throw new ConflictException();
 		}
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -265,6 +265,15 @@ export class ChatService {
 				PaticipantStatus.BANNED
 			) {
 				throw new UnauthorizedException();
+			} else if (
+				this.getParticipantStatus(room.participants, user) ==
+				PaticipantStatus.KICKED
+			) {
+				this.chatParticipantRepository.setParticipantStatus(
+					roomId,
+					{ user, status: PaticipantStatus.DEFAULT },
+					null
+				);
 			}
 			throw new ConflictException();
 		}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -359,8 +359,8 @@ export class ChatService {
 	 * @param roomId
 	 * @returns 참여자 리스트를 반환한다.
 	 */
-	getPariticipants(roomId: number): Promise<ChatParticipantDto[]> {
-		return this.chatParticipantRepository.getPariticipants(roomId);
+	getParticipants(roomId: number): Promise<ChatParticipantDto[]> {
+		return this.chatParticipantRepository.getParticipants(roomId);
 	}
 
 	/**

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -261,9 +261,6 @@ export class ChatService {
 		createChatRoomDto: CreateChatRoomDto
 	): Promise<void> {
 		const room = await this.chatRoomRepository.getChatRoom(roomId);
-		if ((room.roomType = ChatRoomType.PRIVATE)) {
-			throw new UnauthorizedException();
-		}
 		return this.chatRoomRepository.setChatRoomInfo(roomId, createChatRoomDto);
 	}
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -11,6 +11,7 @@ import { ChatRoomDto } from 'src/chat/dto/chat-room.dto';
 import { ChatDto } from 'src/chat/dto/chat.dto';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
+import { DmDto } from 'src/chat/dto/dm.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
 import { GetDMDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
@@ -216,6 +217,49 @@ export class ChatService {
 
 		const room = await this.chatRoomRepository.getChatRoom(emptyRoom.id);
 		return this.roomEntityToDto(room);
+	}
+
+	/**
+	 * chat-room을 DmDto로 변환한다.
+	 * @param room
+	 * @param userId
+	 * @returns 변환된 DmDto를 반환한다.
+	 */
+	roomToDmDto(room: ChatRoom, userId: number): DmDto {
+		const chatMate = room.participants.filter(
+			(participant) => participant.user.id !== userId
+		)[0].user;
+
+		const dm: DmDto = {
+			id: room.id,
+			chatMate: chatMate,
+			updatedTime: room.updatedTime,
+			status: room.status,
+		};
+		return dm;
+	}
+
+	/**
+	 * chat-room리스트를 전달받아 DmDto리스트로 변환한다.
+	 * @param rooms
+	 * @param userId
+	 * @returns 변한된 DmDto 리스트를 반환한다.
+	 */
+	roomsToDmDto(rooms: ChatRoom[], userId: number): DmDto[] {
+		return rooms.map((room) => {
+			return this.roomToDmDto(room, userId);
+		});
+	}
+
+	/**
+	 * 유저가 참여하고있는 모든 dm을 조회한다.
+	 * @param userId
+	 * @returns 참여하고있는 dm 리스트를 반환한다.
+	 */
+	async inquireDM(userId: number): Promise<DmDto[]> {
+		const rooms = await this.chatRoomRepository.inquireDM(userId);
+
+		return this.roomsToDmDto(rooms, userId);
 	}
 
 	/**

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -258,7 +258,7 @@ export class ChatService {
 				throw new UnauthorizedException();
 			}
 		}
-		const user = await this.userRepository.findUserById(1); //temp
+		const user = await this.userRepository.findUserById(2); //temp
 		if (this.checkUserInParticipant(room.participants, user)) {
 			if (
 				this.getParticipantStatus(room.participants, user) ==
@@ -274,6 +274,7 @@ export class ChatService {
 					{ user, status: PaticipantStatus.DEFAULT },
 					null
 				);
+				return this.roomEntityToDto(room);
 			}
 			throw new ConflictException();
 		}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -12,7 +12,7 @@ import { ChatDto } from 'src/chat/dto/chat.dto';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
-import { GetDMDto } from 'src/chat/dto/get-DM.dto';
+import { GetDMDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
 import { SetParticipantStatusDto } from 'src/chat/dto/set-participant-status.dto';
 import { ChatParticipant } from 'src/chat/entities/chat-participant.entity';

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -13,7 +13,7 @@ import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { CreateChatDto } from 'src/chat/dto/create-chat.dto';
 import { DmDto } from 'src/chat/dto/dm.dto';
 import { EnterChatRoomDto } from 'src/chat/dto/enter-chat-room.dto';
-import { GetDMDto } from 'src/chat/dto/get-dm.dto';
+import { GetDmDto } from 'src/chat/dto/get-dm.dto';
 import { SetParticipantRoleDto } from 'src/chat/dto/set-participant-role.dto';
 import { SetParticipantStatusDto } from 'src/chat/dto/set-participant-status.dto';
 import { ChatParticipant } from 'src/chat/entities/chat-participant.entity';
@@ -123,9 +123,9 @@ export class ChatService {
 	 * @param getPrivateChatRoomDto 대화를 나눌 유저의 정보가 담긴 dto
 	 * @returns dm room을 반환한다.
 	 */
-	async getDM(getDMDto: GetDMDto): Promise<ChatRoomDto> {
+	async getDm(getDmDto: GetDmDto): Promise<ChatRoomDto> {
 		const user = await this.userRepository.getUserInfobyIdx(1); //temp
-		const chatMateId = getDMDto.chatMate.id;
+		const chatMateId = getDmDto.chatMate.id;
 		if (user.id === chatMateId) {
 			throw new ConflictException();
 		}
@@ -134,12 +134,12 @@ export class ChatService {
 			throw new NotFoundException();
 		}
 
-		const roomName = this.createDMName(user.id, chatMateId);
-		const room = await this.chatRoomRepository.getDM(roomName);
+		const roomName = this.createDmName(user.id, chatMateId);
+		const room = await this.chatRoomRepository.getDm(roomName);
 		if (room !== null) {
 			return this.roomEntityToDto(room);
 		}
-		return this.createDM(user, chatMate);
+		return this.createDm(user, chatMate);
 	}
 
 	/**
@@ -148,7 +148,7 @@ export class ChatService {
 	 * @param chatMateId
 	 * @returns roomName을 반환한다.
 	 */
-	createDMName(userId: number, chatMateId: number): string {
+	createDmName(userId: number, chatMateId: number): string {
 		if (userId < chatMateId) {
 			return `DM ${userId}, ${chatMateId}`;
 		}
@@ -161,10 +161,10 @@ export class ChatService {
 	 * @param chatMate
 	 * @returns dm room을 반환한다.
 	 */
-	async createDM(user: User, chatMate: User): Promise<ChatRoomDto> {
-		const roomName = this.createDMName(user.id, chatMate.id);
-		const emptyRoom = await this.chatRoomRepository.createDM(roomName);
-		await this.chatParticipantRepository.createDM(emptyRoom, user, chatMate);
+	async createDm(user: User, chatMate: User): Promise<ChatRoomDto> {
+		const roomName = this.createDmName(user.id, chatMate.id);
+		const emptyRoom = await this.chatRoomRepository.createDm(roomName);
+		await this.chatParticipantRepository.createDm(emptyRoom, user, chatMate);
 		const room = await this.chatRoomRepository.getChatRoom(emptyRoom.id);
 		return this.roomEntityToDto(room);
 	}
@@ -256,8 +256,8 @@ export class ChatService {
 	 * @param userId
 	 * @returns 참여하고있는 dm 리스트를 반환한다.
 	 */
-	async inquireDM(userId: number): Promise<DmDto[]> {
-		const rooms = await this.chatRoomRepository.inquireDM(userId);
+	async inquireDm(userId: number): Promise<DmDto[]> {
+		const rooms = await this.chatRoomRepository.inquireDm(userId);
 
 		return this.roomsToDmDto(rooms, userId);
 	}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -233,9 +233,11 @@ export class ChatService {
 	 * 존재하는 오픈 채팅방을 조회한다.
 	 * @returns 존재하는 오픈 채팅방 리스트를 반환한다.
 	 */
-	async inquireOpenedChatRoom(): Promise<ChatRoomDto[]> {
+	async inquireOpenedChatRoom(userId: number): Promise<ChatRoomDto[]> {
+		const user = await this.userRepository.findUserById(userId); //temp
+
 		return this.roomsEntityToDto(
-			await this.chatRoomRepository.inquireOpenedChatRoom()
+			await this.chatRoomRepository.inquireOpenedChatRoom(user)
 		);
 	}
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -80,7 +80,7 @@ export class ChatService {
 	 */
 	async checkIfRoomExist(roomId: number): Promise<boolean> {
 		const room = await this.chatRoomRepository.getChatRoom(roomId);
-		if (room == null) {
+		if (room === null) {
 			return false;
 		}
 		return true;
@@ -107,7 +107,7 @@ export class ChatService {
 		user: User
 	): PaticipantStatus {
 		const participant = participants.find((participant) => {
-			if (participant.user.id == user.id) {
+			if (participant.user.id === user.id) {
 				return participant;
 			}
 		});
@@ -125,17 +125,17 @@ export class ChatService {
 	async getDM(getDMDto: GetDMDto): Promise<ChatRoomDto> {
 		const user = await this.userRepository.getUserInfobyIdx(1); //temp
 		const chatMateId = getDMDto.chatMate.id;
-		if (user.id == chatMateId) {
+		if (user.id === chatMateId) {
 			throw new ConflictException();
 		}
 		const chatMate = await this.userRepository.getUserInfobyIdx(chatMateId);
-		if (chatMate == null) {
+		if (chatMate === null) {
 			throw new NotFoundException();
 		}
 
 		const roomName = this.createDMName(user.id, chatMateId);
 		const room = await this.chatRoomRepository.getDM(roomName);
-		if (room != null) {
+		if (room !== null) {
 			return this.roomEntityToDto(room);
 		}
 		return this.createDM(user, chatMate);
@@ -260,10 +260,10 @@ export class ChatService {
 	): Promise<ChatRoomDto> {
 		const room = await this.chatRoomRepository.getChatRoom(roomId);
 		if (
-			room.roomType == ChatRoomType.PROTECTED &&
-			enterChatRoomDto.password != null
+			room.roomType === ChatRoomType.PROTECTED &&
+			enterChatRoomDto.password !== null
 		) {
-			if (enterChatRoomDto.password != room.password) {
+			if (enterChatRoomDto.password !== room.password) {
 				throw new UnauthorizedException();
 			}
 		}
@@ -299,7 +299,7 @@ export class ChatService {
 	 */
 	async getChatRoom(roomId: number): Promise<ChatRoomDto> {
 		const room = await this.chatRoomRepository.getChatRoom(roomId);
-		if (room == null) {
+		if (room === null) {
 			throw new NotFoundException();
 		}
 		return this.roomEntityToDto(
@@ -354,7 +354,7 @@ export class ChatService {
 			roomId,
 			1
 		); //userId temp
-		if (participant == null) {
+		if (participant === null) {
 			throw new NotFoundException();
 		}
 
@@ -384,15 +384,15 @@ export class ChatService {
 			roomId,
 			setParticipantDto.user.id
 		);
-		if (participant == null) {
+		if (participant === null) {
 			throw new NotFoundException();
 		}
 
-		if (participant.role == Role.OWNER) {
+		if (participant.role === Role.OWNER) {
 			throw new UnauthorizedException();
 		}
 
-		if (setParticipantDto.status == PaticipantStatus.MUTED) {
+		if (setParticipantDto.status === PaticipantStatus.MUTED) {
 			const mutedTime = new Date();
 			mutedTime.setMinutes(mutedTime.getMinutes() + 5);
 			return this.chatParticipantRepository.setParticipantStatus(
@@ -422,7 +422,7 @@ export class ChatService {
 			roomId,
 			setParticipantDto.user.id
 		);
-		if (participant == null) {
+		if (participant === null) {
 			throw new NotFoundException();
 		}
 
@@ -442,7 +442,7 @@ export class ChatService {
 		const deletedParticipant =
 			await this.chatParticipantRepository.deleteParticipant(roomId, userId);
 
-		if (deletedParticipant == null) {
+		if (deletedParticipant === null) {
 			throw new NotFoundException();
 		}
 	}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -225,7 +225,7 @@ export class ChatService {
 		const user = await this.userRepository.findUserById(userId); //temp
 
 		return this.roomsEntityToDto(
-			await this.chatParticipantRepository.inquireChatRoom(user)
+			await this.chatRoomRepository.inquireChatRoom(user)
 		);
 	}
 

--- a/src/chat/dto/create-chat-room.dto.ts
+++ b/src/chat/dto/create-chat-room.dto.ts
@@ -19,7 +19,7 @@ export class CreateChatRoomDto {
 	roomType: ChatRoomType;
 
 	@ApiProperty({ description: '비밀번호' })
-	@ValidateIf((room) => room.roomType == ChatRoomType.PROTECTED)
+	@ValidateIf((room) => room.roomType === ChatRoomType.PROTECTED)
 	@IsNotEmpty()
 	// @IsHash()
 	password: number | null;

--- a/src/chat/dto/create-chat-room.dto.ts
+++ b/src/chat/dto/create-chat-room.dto.ts
@@ -15,7 +15,6 @@ export class CreateChatRoomDto {
 
 	@ApiProperty({ description: '채팅방 타입' })
 	@IsEnum(ChatRoomType)
-	@NotEquals(ChatRoomType.PRIVATE)
 	roomType: ChatRoomType;
 
 	@ApiProperty({ description: '비밀번호' })

--- a/src/chat/dto/create-chat-room.dto.ts
+++ b/src/chat/dto/create-chat-room.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomType } from 'src/chat/enums/chat-room-type.enum';
-import { IsNotEmpty, IsEnum, ValidateIf, IsHash } from 'class-validator';
+import {
+	IsNotEmpty,
+	IsEnum,
+	ValidateIf,
+	IsHash,
+	NotEquals,
+} from 'class-validator';
 
 export class CreateChatRoomDto {
 	@ApiProperty({ description: '채팅방 이름' })
@@ -9,6 +15,7 @@ export class CreateChatRoomDto {
 
 	@ApiProperty({ description: '채팅방 타입' })
 	@IsEnum(ChatRoomType)
+	@NotEquals(ChatRoomType.DM)
 	roomType: ChatRoomType;
 
 	@ApiProperty({ description: '비밀번호' })

--- a/src/chat/dto/create-chat-room.dto.ts
+++ b/src/chat/dto/create-chat-room.dto.ts
@@ -1,12 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ChatRoomType } from 'src/chat/enums/chat-room-type.enum';
-import {
-	IsNotEmpty,
-	IsEnum,
-	ValidateIf,
-	IsHash,
-	NotEquals,
-} from 'class-validator';
+import { IsNotEmpty, IsEnum, ValidateIf, IsHash } from 'class-validator';
 
 export class CreateChatRoomDto {
 	@ApiProperty({ description: '채팅방 이름' })
@@ -22,4 +16,7 @@ export class CreateChatRoomDto {
 	@IsNotEmpty()
 	// @IsHash()
 	password: number | null;
+
+	@ApiProperty({ description: '참가할 유저들 리스트' })
+	participants: number[];
 }

--- a/src/chat/dto/dm.dto.ts
+++ b/src/chat/dto/dm.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { User } from 'src/user/entities/user.entity';
+
+export class DmDto {
+	@ApiProperty({ description: '채팅방 인덱스' })
+	id: number;
+
+	@ApiProperty({ description: '디엠 상대방' })
+	chatMate: User;
+
+	@ApiProperty({ description: '채팅방 최근 업데이트 시간' })
+	updatedTime: Date;
+
+	@ApiProperty({ description: '채팅방 상태' })
+	status: boolean;
+}

--- a/src/chat/dto/get-dm.dto.ts
+++ b/src/chat/dto/get-dm.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 import { UserDto } from 'src/user/dto/user.dto';
 
-export class GetDMDto {
+export class GetDmDto {
 	@ApiProperty({ description: 'dm 상대방' })
 	@IsNotEmpty()
 	chatMate: UserDto;

--- a/src/chat/dto/get-dm.dto.ts
+++ b/src/chat/dto/get-dm.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty } from 'class-validator';
 import { UserDto } from 'src/user/dto/user.dto';
 
-export class GetPrivateChatRoomDto {
+export class GetDMDto {
 	@ApiProperty({ description: 'dm 상대방' })
 	@IsNotEmpty()
 	chatMate: UserDto;

--- a/src/chat/enums/chat-room-type.enum.ts
+++ b/src/chat/enums/chat-room-type.enum.ts
@@ -2,4 +2,5 @@ export enum ChatRoomType {
 	PUBLIC = 'PUBLIC',
 	PROTECTED = 'PROTECTED',
 	PRIVATE = 'PRIVATE',
+	DM = 'DM',
 }

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -68,19 +68,6 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 		await this.save(participants);
 	}
 
-	async inquireChatRoom(user: UserDto): Promise<ChatRoom[]> {
-		const query = this.createQueryBuilder('participant');
-
-		const users = await query
-			.leftJoinAndSelect('participant.room', 'room')
-			.leftJoinAndSelect('participant.user', 'user')
-			.where('user.id=:userId', { userId: user.id })
-			.getMany();
-
-		const rooms = users.map((user) => user.room);
-		return rooms;
-	}
-
 	async getParticipant(
 		roomId: number,
 		userId: number

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -36,8 +36,8 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 		await this.save([firstParticipant, secondParticipant]);
 	}
 
-	async createChatRoom(room: ChatRoom, user: User): Promise<void> {
-		const participant = this.create({
+	async registerOwner(room: ChatRoom, user: User) {
+		const owner = this.create({
 			room,
 			user,
 			role: Role.OWNER,
@@ -45,7 +45,27 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 			muteExpirationTime: null,
 		});
 
-		await this.save(participant);
+		await this.save(owner);
+	}
+
+	async createChatRoom(
+		room: ChatRoom,
+		owner: User,
+		users: UserDto[]
+	): Promise<void> {
+		this.registerOwner(room, owner);
+
+		const participants = users.map((user) => {
+			return this.create({
+				room,
+				user,
+				role: Role.MEMBER,
+				status: PaticipantStatus.DEFAULT,
+				muteExpirationTime: null,
+			});
+		});
+
+		await this.save(participants);
 	}
 
 	async inquireChatRoom(user: UserDto): Promise<ChatRoom[]> {

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -148,7 +148,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 			.andWhere('participant.roomId = :roomId', { roomId })
 			.getOne();
 
-		if (participant == null) {
+		if (participant === null) {
 			return null;
 		}
 		this.delete(participant.id);

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -16,7 +16,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 		super(ChatParticipant, dataSource.createEntityManager());
 	}
 
-	async createDM(room: ChatRoom, user: User, chatMate: User): Promise<void> {
+	async createDm(room: ChatRoom, user: User, chatMate: User): Promise<void> {
 		const firstParticipant = this.create({
 			room,
 			user,

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -94,7 +94,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 		await this.save(participant);
 	}
 
-	async getPariticipants(roomId: number): Promise<ChatParticipantDto[]> {
+	async getParticipants(roomId: number): Promise<ChatParticipantDto[]> {
 		const query = this.createQueryBuilder('participant');
 
 		const participants = await query

--- a/src/chat/repositories/chat-participant.repository.ts
+++ b/src/chat/repositories/chat-participant.repository.ts
@@ -16,11 +16,7 @@ export class ChatParticipantRepository extends Repository<ChatParticipant> {
 		super(ChatParticipant, dataSource.createEntityManager());
 	}
 
-	async createPrivateChatRoom(
-		room: ChatRoom,
-		user: User,
-		chatMate: User
-	): Promise<void> {
+	async createDM(room: ChatRoom, user: User, chatMate: User): Promise<void> {
 		const firstParticipant = this.create({
 			room,
 			user,

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -40,7 +40,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 	async createDM(roomName: string): Promise<ChatRoom> {
 		const chatRoom = this.create({
 			roomName,
-			roomType: ChatRoomType.PRIVATE,
+			roomType: ChatRoomType.DM,
 			password: null,
 		});
 

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { ChatRoom } from 'src/chat/entities/chat-room.entity';
 import { ChatRoomType } from 'src/chat/enums/chat-room-type.enum';
+import { UserDto } from 'src/user/dto/user.dto';
 import { DataSource, Repository } from 'typeorm';
 
 @Injectable()
@@ -56,6 +57,18 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 			.leftJoinAndSelect('participant.user', 'user')
 			.where('room.roomType = :open', { open: ChatRoomType.PUBLIC })
 			.orWhere('room.roomType = :open', { open: ChatRoomType.PROTECTED })
+			.getMany();
+
+		return rooms;
+	}
+
+	async inquireChatRoom(user: UserDto): Promise<ChatRoom[]> {
+		const query = this.createQueryBuilder('room');
+
+		const rooms = await query
+			.leftJoinAndSelect('room.participants', 'participant')
+			.leftJoinAndSelect('participant.user', 'user')
+			.where('user.id=:userId', { userId: user.id })
 			.getMany();
 
 		return rooms;

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -50,19 +50,6 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return chatRoom;
 	}
 
-	async inquireOpenedChatRoom(): Promise<ChatRoom[]> {
-		const query = this.createQueryBuilder('room');
-
-		const rooms = await query
-			.leftJoinAndSelect('room.participants', 'participant')
-			.leftJoinAndSelect('participant.user', 'user')
-			.where('room.roomType = :open', { open: ChatRoomType.PUBLIC })
-			.orWhere('room.roomType = :open', { open: ChatRoomType.PROTECTED })
-			.getMany();
-
-		return rooms;
-	}
-
 	async inquireChatRoom(user: UserDto): Promise<ChatRoom[]> {
 		const query = this.createQueryBuilder('room');
 
@@ -73,6 +60,19 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 			.andWhere('participant.status IN (:...types)', {
 				types: [PaticipantStatus.DEFAULT, PaticipantStatus.MUTED],
 			})
+			.getMany();
+
+		return rooms;
+	}
+
+	async inquireOpenedChatRoom(user: UserDto): Promise<ChatRoom[]> {
+		const query = this.createQueryBuilder('room');
+
+		const rooms = await query
+			.leftJoinAndSelect('room.participants', 'participant')
+			.leftJoinAndSelect('participant.user', 'user')
+			.where('room.roomType = :open', { open: ChatRoomType.PUBLIC })
+			.orWhere('room.roomType = :open', { open: ChatRoomType.PROTECTED })
 			.getMany();
 
 		return rooms;

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -27,7 +27,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return chatRoom;
 	}
 
-	async inquireDM(userId: number): Promise<ChatRoom[]> {
+	async inquireDm(userId: number): Promise<ChatRoom[]> {
 		const query = this.createQueryBuilder('room');
 
 		const dms = await query
@@ -42,7 +42,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return dms;
 	}
 
-	async getDM(roomName: string): Promise<ChatRoom> {
+	async getDm(roomName: string): Promise<ChatRoom> {
 		const query = this.createQueryBuilder('room');
 
 		const room = await query
@@ -54,7 +54,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return room;
 	}
 
-	async createDM(roomName: string): Promise<ChatRoom> {
+	async createDm(roomName: string): Promise<ChatRoom> {
 		const chatRoom = this.create({
 			roomName,
 			roomType: ChatRoomType.DM,

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -25,7 +25,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return chatRoom;
 	}
 
-	async getPrivateChatRoom(roomName: string): Promise<ChatRoom> {
+	async getDM(roomName: string): Promise<ChatRoom> {
 		const query = this.createQueryBuilder('room');
 
 		const room = await query
@@ -37,7 +37,7 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return room;
 	}
 
-	async createPrivateChatRoom(roomName: string): Promise<ChatRoom> {
+	async createDM(roomName: string): Promise<ChatRoom> {
 		const chatRoom = this.create({
 			roomName,
 			roomType: ChatRoomType.PRIVATE,

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { CreateChatRoomDto } from 'src/chat/dto/create-chat-room.dto';
 import { ChatRoom } from 'src/chat/entities/chat-room.entity';
 import { ChatRoomType } from 'src/chat/enums/chat-room-type.enum';
+import { PaticipantStatus } from 'src/chat/enums/paticipant-status.enum';
 import { UserDto } from 'src/user/dto/user.dto';
 import { DataSource, Repository } from 'typeorm';
 
@@ -69,6 +70,9 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 			.leftJoinAndSelect('room.participants', 'participant')
 			.leftJoinAndSelect('participant.user', 'user')
 			.where('user.id=:userId', { userId: user.id })
+			.andWhere('participant.status IN (:...types)', {
+				types: [PaticipantStatus.DEFAULT, PaticipantStatus.MUTED],
+			})
 			.getMany();
 
 		return rooms;

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -72,8 +72,15 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 			.leftJoinAndSelect('room.participants', 'participant')
 			.leftJoinAndSelect('participant.user', 'user')
 			.where('user.id=:userId', { userId: user.id })
-			.andWhere('participant.status IN (:...types)', {
-				types: [PaticipantStatus.DEFAULT, PaticipantStatus.MUTED],
+			.andWhere('room.roomType IN (:...types)', {
+				types: [
+					ChatRoomType.PRIVATE,
+					ChatRoomType.PROTECTED,
+					ChatRoomType.PUBLIC,
+				],
+			})
+			.andWhere('participant.status IN (:...status)', {
+				status: [PaticipantStatus.DEFAULT, PaticipantStatus.MUTED],
 			})
 			.getMany();
 

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -27,6 +27,21 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return chatRoom;
 	}
 
+	async inquireDM(userId: number): Promise<ChatRoom[]> {
+		const query = this.createQueryBuilder('room');
+
+		const dms = await query
+			.leftJoinAndSelect('room.participants', 'participant')
+			.leftJoinAndSelect('participant.user', 'user')
+			.where('room.roomType = :dm', { dm: ChatRoomType.DM })
+			.andWhere('user.id = :userId', { userId })
+			.leftJoinAndSelect('room.participants', 'all_participant')
+			.leftJoinAndSelect('all_participant.user', 'all_user')
+			.getMany();
+
+		return dms;
+	}
+
 	async getDM(roomName: string): Promise<ChatRoom> {
 		const query = this.createQueryBuilder('room');
 

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -52,6 +52,8 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		const query = this.createQueryBuilder('room');
 
 		const rooms = await query
+			.leftJoinAndSelect('room.participants', 'participant')
+			.leftJoinAndSelect('participant.user', 'user')
 			.where('room.roomType = :open', { open: ChatRoomType.PUBLIC })
 			.orWhere('room.roomType = :open', { open: ChatRoomType.PROTECTED })
 			.getMany();

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -71,8 +71,9 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		const rooms = await query
 			.leftJoinAndSelect('room.participants', 'participant')
 			.leftJoinAndSelect('participant.user', 'user')
-			.where('room.roomType = :open', { open: ChatRoomType.PUBLIC })
-			.orWhere('room.roomType = :open', { open: ChatRoomType.PROTECTED })
+			.where('room.roomType IN (:...open)', {
+				open: [ChatRoomType.PUBLIC, ChatRoomType.PROTECTED],
+			})
 			.getMany();
 
 		return rooms;


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->

chat module에서 일어나야하는 예외 처리와 추가 기능을 구현했습니다.

## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->

- private chat-room과 dm이 분리됐습니다. 
  - dto, 함수명을 변경하여 dm생성을 분리했습니다.
  - private은 변경할 수 없도록 예외 처리 하던 부분을 수정했습니다.
  - private챗룸을 생성할 수 있도록 했습니다.
 - private챗룸 기능이 생기며 사용자 초대 기능이 필요하게 됐습니다.
   - 챗룸을 생성할 때 추가해둘 사용자를 선택할 수 있도록 했습니다.
   - 생성할 때 오너가 선택해둔 사용자들을 챗룸에 참여시켰습니다.
 - kick, ban 당한 챗룸은 참여중인 챗룸 리스트에 나오지않도록 수정했습니다.
 - kick된 유저가 챗룸에 재입장하면 default상태로 변경하도록 했습니다.
 - ban된 유저는 챗룸에 재입장 불가하도록 했습니다.
 - 채팅방을 탐색할 때 밴당한 적 있는 챗룸은 목록에서 보이지않도록 했습니다.

## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat와 domain을 연결해주세요!
domain을 먼저 언급해주세요
-->
- #7

<!-- ScreenShot [optional] -->
