### PR TITLE
[feat] set channel name bold after reconnect #44

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -42,7 +42,7 @@ export class AuthService {
 		return await this.userRepository.findUserById(id);
 	}
 
-	async getUserIdFromToken(token: string): Promise<User> {
+	async getUserByIdFromToken(token: string): Promise<User> {
 		const payload = this.jwtService.verify(token);
 
 		if (!payload.id) {

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -90,6 +90,16 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		}
 	}
 
+	@SubscribeMessage('readChat')
+	@UseGuards(RoomGuard)
+	async readChat(client: Socket, data: { roomId: number }): Promise<void> {
+		try {
+			const user = await this.getUserFromToken(client);
+
+			await this.chatService.updateReadTime(data.roomId, user.id);
+		} catch (e) {}
+	}
+
 	@SubscribeMessage('sendChat')
 	@UseGuards(RoomGuard)
 	@UsePipes(ValidationPipe)
@@ -100,6 +110,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			const room = await this.chatService.getChatRoom(roomId);
 
 			const newChat = await this.chatService.createChat(user.id, createChatDto);
+
+			await this.chatService.updateChatRoomUpdateTime(roomId);
 
 			if (room.roomType === ChatRoomType.DM) {
 				this.server

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -72,6 +72,24 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 		return user;
 	}
 
+	@SubscribeMessage('getChats')
+	@UseGuards(RoomGuard)
+	async getChats(
+		client: Socket,
+		data: { roomId: number }
+	): Promise<{ status: number; chats: ChatDto[] }> {
+		try {
+			const user = await this.getUserFromToken(client);
+
+			await this.chatService.updateReadTime(data.roomId, user.id);
+
+			const chats = await this.chatService.getChats(data.roomId, user.id);
+			return { status: HttpStatus.OK, chats };
+		} catch (e) {
+			return { status: HttpStatus.NOT_FOUND, chats: [] };
+		}
+	}
+
 	@SubscribeMessage('sendChat')
 	@UseGuards(RoomGuard)
 	@UsePipes(ValidationPipe)

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -107,16 +107,6 @@ export class ChatService {
 	}
 
 	/**
-	 * 유저가 room에 참여하고있는지 확인한다. 밴, 킥, 떠난 유저도 포함한다.
-	 * @param participants 확인할 room의 participant목록
-	 * @param user 참여해있는지 확인할 user
-	 * @returns 참여자하면 true, 참여자가 아니라면 false를 반환한다.
-	 */
-	checkUserInParticipant(participants: ChatParticipant[], user: User): boolean {
-		return participants.some((participant) => participant.user.id === user.id);
-	}
-
-	/**
 	 * 채팅방 참가자의 상태를 확인한다.
 	 * @param participants
 	 * @param user
@@ -470,8 +460,6 @@ export class ChatService {
 	 * @returns 챗 리스트를 반환한다.
 	 */
 	async getChats(roomId: number, userId: number): Promise<ChatDto[]> {
-		await this.updateReadTime(roomId, userId);
-
 		return this.chatRepository.getChats(roomId);
 	}
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -72,6 +72,11 @@ export class ChatService {
 	 * @returns
 	 */
 	roomEntityToDto(room: ChatRoom, participant: ChatParticipant): ChatRoomDto {
+		const leftToRead =
+			participant === null || room.updatedTime <= participant.lastReadTime
+				? false
+				: true;
+
 		const dto: ChatRoomDto = {
 			id: room.id,
 			roomName: room.roomName,
@@ -85,10 +90,7 @@ export class ChatService {
 					participant.status === PaticipantStatus.MUTED
 			).length,
 			participants: room.participants,
-			leftToRead:
-				participant === null || room.updatedTime <= participant.lastReadTime
-					? false
-					: true,
+			leftToRead,
 		};
 		return dto;
 	}
@@ -451,6 +453,10 @@ export class ChatService {
 
 	async updateReadTime(roomId: number, userId: number): Promise<void> {
 		return this.chatParticipantRepository.updateReadTime(roomId, userId);
+	}
+
+	async updateChatRoomUpdateTime(roomId: number): Promise<void> {
+		return this.chatRoomRepository.updateChatRoomUpdateTime(roomId);
 	}
 
 	/**

--- a/src/chat/entities/chat-participant.entity.ts
+++ b/src/chat/entities/chat-participant.entity.ts
@@ -14,7 +14,7 @@ import {
 
 @Entity('ChatParticipant')
 export class ChatParticipant {
-	@PrimaryGeneratedColumn({ name: 'id' })
+	@PrimaryGeneratedColumn({ name: 'id', type: 'bigint' })
 	id: number;
 
 	@ManyToOne(() => ChatRoom, (room) => room.participants, {
@@ -27,18 +27,18 @@ export class ChatParticipant {
 	@JoinColumn({ name: 'userId' })
 	user: User;
 
-	@Column({ name: 'role' })
+	@Column({ name: 'role', type: 'varchar' })
 	role: Role;
 
-	@Column({ name: 'status' })
+	@Column({ name: 'status', type: 'varchar' })
 	status: PaticipantStatus;
 
-	@Column({ name: 'mute_expiration_time', nullable: true })
+	@Column({ name: 'mute_expiration_time', nullable: true, type: 'timestamp' })
 	muteExpirationTime: Date | null;
 
 	@OneToMany(() => Chat, (chat) => chat.user)
 	chats: Chat[];
 
-	@Column({ name: 'last_read_time' })
+	@Column({ name: 'last_read_time', type: 'timestamp' })
 	lastReadTime: Date;
 }

--- a/src/chat/entities/chat-room.entity.ts
+++ b/src/chat/entities/chat-room.entity.ts
@@ -13,26 +13,26 @@ import {
 
 @Entity('ChatRoom')
 export class ChatRoom {
-	@PrimaryGeneratedColumn({ name: 'id' })
+	@PrimaryGeneratedColumn({ name: 'id', type: 'bigint' })
 	id: number;
 
-	@Column({ name: 'room_name' })
+	@Column({ name: 'room_name', type: 'varchar', length: 80 })
 	@MaxLength(80)
 	roomName: string;
 
-	@Column({ name: 'room_type' })
+	@Column({ name: 'room_type', type: 'varchar' })
 	roomType: ChatRoomType;
 
-	@Column({ name: 'password', nullable: true })
+	@Column({ name: 'password', nullable: true, type: 'text' })
 	password: string | null;
 
-	@CreateDateColumn({ name: 'created_at' })
+	@CreateDateColumn({ name: 'created_at', type: 'timestamp' })
 	createdAt: Date;
 
-	@UpdateDateColumn({ name: 'update_time' })
+	@UpdateDateColumn({ name: 'update_time', type: 'timestamp' })
 	updatedTime: Date;
 
-	@Column({ name: 'status', default: true })
+	@Column({ name: 'status', default: true, type: 'boolean' })
 	status: boolean;
 
 	@OneToMany(() => Chat, (chat) => chat.room)

--- a/src/chat/entities/chat.entity.ts
+++ b/src/chat/entities/chat.entity.ts
@@ -12,7 +12,7 @@ import {
 
 @Entity('Chat')
 export class Chat {
-	@PrimaryGeneratedColumn({ name: 'id' })
+	@PrimaryGeneratedColumn({ name: 'id', type: 'bigint' })
 	id: number;
 
 	@ManyToOne(() => ChatParticipant, (user) => user.chats)
@@ -23,10 +23,10 @@ export class Chat {
 	@JoinColumn({ name: 'roomId' })
 	room: ChatRoom;
 
-	@Column({ name: 'content' })
+	@Column({ name: 'content', type: 'varchar', length: 4000 })
 	@MaxLength(4000)
 	content: string;
 
-	@CreateDateColumn({ name: 'sent_time' })
+	@CreateDateColumn({ name: 'sent_time', type: 'timestamp' })
 	sentTime: Date;
 }

--- a/src/chat/repositories/chat-room.repository.ts
+++ b/src/chat/repositories/chat-room.repository.ts
@@ -27,6 +27,14 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
 		return chatRoom;
 	}
 
+	async updateChatRoomUpdateTime(roomId: number): Promise<void> {
+		const query = this.createQueryBuilder();
+
+		query.update(ChatRoom).set({}).where('id = :roomId', { roomId }).execute();
+
+		return;
+	}
+
 	async getDm(roomName: string): Promise<ChatRoom> {
 		const query = this.createQueryBuilder('room');
 


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->

- 안읽은 메시지가 있는 채널이름의 폰트가 bold가 되도록했습니다.
- 수정하면서 만난 에러들을 수정했습니다.

## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->

- 엔티티 필드에 타입을 명시에 항상 같은 타입인 속성을 가진 테이블이 생성되도록 했습니다.
- 채팅 내역을 받기위해 기존 http통신을 사용하는 방식에서 소켓 통신으로 수정했습니다.
- 사용자가 마지막으로 메시지를 확인한 시간을 기록하여 재접속했을 때 읽지않은 메시지가 있는 채널은 채널명 폰트가 달라지도록 했습니다.
- 킥, 밴된 참여자가 채팅방을 나가게되도록 수정했습니다.

## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat와 domain을 연결해주세요!
domain을 먼저 언급해주세요
-->
- #44

<!-- ScreenShot [optional] -->
